### PR TITLE
Bug: Sinking Animation Resets Origin (0, 0, 0)

### DIFF
--- a/workers/unity/Assets/EntityPrefabs/PirateShip.prefab
+++ b/workers/unity/Assets/EntityPrefabs/PirateShip.prefab
@@ -2,7 +2,7 @@
 %TAG !u! tag:unity3d.com,2011:
 --- !u!1 &101646
 GameObject:
-  m_ObjectHideFlags: 0
+  m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 4
@@ -33,8 +33,6 @@ GameObject:
   - 114: {fileID: 11490060}
   - 114: {fileID: 11441326}
   - 114: {fileID: 11484910}
-  - 111: {fileID: 11183426}
-  - 114: {fileID: 11426928}
   - 114: {fileID: 11410120}
   - 114: {fileID: 11472412}
   m_Layer: 0
@@ -46,7 +44,7 @@ GameObject:
   m_IsActive: 1
 --- !u!1 &113582
 GameObject:
-  m_ObjectHideFlags: 0
+  m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 4
@@ -148,14 +146,13 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 107220}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 2.5786302, y: -0.8491726, z: -1.4117618}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
-  - {fileID: 467550}
-  - {fileID: 442014}
   - {fileID: 427688}
   - {fileID: 454740}
+  - {fileID: 4000011024296222}
   m_Father: {fileID: 0}
   m_RootOrder: 0
 --- !u!4 &427688
@@ -171,7 +168,7 @@ Transform:
   m_Children:
   - {fileID: 459558}
   m_Father: {fileID: 421518}
-  m_RootOrder: 2
+  m_RootOrder: 0
 --- !u!4 &442014
 Transform:
   m_ObjectHideFlags: 1
@@ -183,7 +180,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
-  m_Father: {fileID: 421518}
+  m_Father: {fileID: 4000011024296222}
   m_RootOrder: 1
 --- !u!4 &446462
 Transform:
@@ -211,7 +208,7 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 421518}
-  m_RootOrder: 3
+  m_RootOrder: 1
 --- !u!4 &459558
 Transform:
   m_ObjectHideFlags: 1
@@ -237,7 +234,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
-  m_Father: {fileID: 421518}
+  m_Father: {fileID: 4000011024296222}
   m_RootOrder: 0
 --- !u!4 &499136
 Transform:
@@ -427,21 +424,6 @@ Light:
   m_BounceIntensity: 1.77
   m_ShadowRadius: 0
   m_ShadowAngle: 0
---- !u!111 &11183426
-Animation:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 107220}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Animation: {fileID: 7400000, guid: a2ff7923bbf1c1a41975b30885537a47, type: 2}
-  m_Animations:
-  - {fileID: 7400000, guid: a2ff7923bbf1c1a41975b30885537a47, type: 2}
-  m_WrapMode: 0
-  m_PlayAutomatically: 0
-  m_AnimatePhysics: 0
-  m_CullingType: 0
 --- !u!114 &11403966
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -508,18 +490,6 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!114 &11426928
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 107220}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a1b04f56ad1bfcf43ad356a7d124ade1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  SinkingAnimation: {fileID: 11183426}
 --- !u!114 &11436858
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -633,3 +603,62 @@ Prefab:
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 107220}
   m_IsPrefabParent: 1
+--- !u!1 &1000014117848522
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 4000011024296222}
+  - 111: {fileID: 111000010068299764}
+  - 114: {fileID: 114000012766388938}
+  m_Layer: 0
+  m_Name: Structure
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4000011024296222
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000014117848522}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 467550}
+  - {fileID: 442014}
+  m_Father: {fileID: 421518}
+  m_RootOrder: 2
+--- !u!111 &111000010068299764
+Animation:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000014117848522}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Animation: {fileID: 7400000, guid: a2ff7923bbf1c1a41975b30885537a47, type: 2}
+  m_Animations:
+  - {fileID: 7400000, guid: a2ff7923bbf1c1a41975b30885537a47, type: 2}
+  m_WrapMode: 0
+  m_PlayAutomatically: 0
+  m_AnimatePhysics: 0
+  m_CullingType: 0
+--- !u!114 &114000012766388938
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000014117848522}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a1b04f56ad1bfcf43ad356a7d124ade1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  SinkingAnimation: {fileID: 111000010068299764}

--- a/workers/unity/Assets/EntityPrefabs/PlayerShip.prefab
+++ b/workers/unity/Assets/EntityPrefabs/PlayerShip.prefab
@@ -2,7 +2,7 @@
 %TAG !u! tag:unity3d.com,2011:
 --- !u!1 &101646
 GameObject:
-  m_ObjectHideFlags: 0
+  m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 4
@@ -33,8 +33,6 @@ GameObject:
   - 114: {fileID: 11490060}
   - 114: {fileID: 11441326}
   - 114: {fileID: 11484910}
-  - 111: {fileID: 11183426}
-  - 114: {fileID: 11426928}
   - 114: {fileID: 11410120}
   - 114: {fileID: 11472412}
   - 114: {fileID: 11466898}
@@ -48,7 +46,7 @@ GameObject:
   m_IsActive: 1
 --- !u!1 &113582
 GameObject:
-  m_ObjectHideFlags: 0
+  m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 4
@@ -150,14 +148,13 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 107220}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 1.0534067, y: -0.4273572, z: -0.766067}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
-  - {fileID: 467550}
-  - {fileID: 442014}
   - {fileID: 427688}
   - {fileID: 454740}
+  - {fileID: 4000011198845316}
   m_Father: {fileID: 0}
   m_RootOrder: 0
 --- !u!4 &427688
@@ -173,7 +170,7 @@ Transform:
   m_Children:
   - {fileID: 459558}
   m_Father: {fileID: 421518}
-  m_RootOrder: 2
+  m_RootOrder: 0
 --- !u!4 &442014
 Transform:
   m_ObjectHideFlags: 1
@@ -185,7 +182,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
-  m_Father: {fileID: 421518}
+  m_Father: {fileID: 4000011198845316}
   m_RootOrder: 1
 --- !u!4 &446462
 Transform:
@@ -213,7 +210,7 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 421518}
-  m_RootOrder: 3
+  m_RootOrder: 1
 --- !u!4 &459558
 Transform:
   m_ObjectHideFlags: 1
@@ -239,7 +236,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
-  m_Father: {fileID: 421518}
+  m_Father: {fileID: 4000011198845316}
   m_RootOrder: 0
 --- !u!4 &499136
 Transform:
@@ -429,21 +426,6 @@ Light:
   m_BounceIntensity: 1.77
   m_ShadowRadius: 0
   m_ShadowAngle: 0
---- !u!111 &11183426
-Animation:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 107220}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Animation: {fileID: 7400000, guid: a2ff7923bbf1c1a41975b30885537a47, type: 2}
-  m_Animations:
-  - {fileID: 7400000, guid: a2ff7923bbf1c1a41975b30885537a47, type: 2}
-  m_WrapMode: 0
-  m_PlayAutomatically: 0
-  m_AnimatePhysics: 0
-  m_CullingType: 0
 --- !u!114 &11410120
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -499,18 +481,6 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!114 &11426928
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 107220}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a1b04f56ad1bfcf43ad356a7d124ade1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  SinkingAnimation: {fileID: 11183426}
 --- !u!114 &11432558
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -658,3 +628,62 @@ Prefab:
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 107220}
   m_IsPrefabParent: 1
+--- !u!1 &1000010207501202
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 4000011198845316}
+  - 111: {fileID: 111000013708133544}
+  - 114: {fileID: 114000011299936470}
+  m_Layer: 0
+  m_Name: Structure
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4000011198845316
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010207501202}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 467550}
+  - {fileID: 442014}
+  m_Father: {fileID: 421518}
+  m_RootOrder: 2
+--- !u!111 &111000013708133544
+Animation:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010207501202}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Animation: {fileID: 7400000, guid: a2ff7923bbf1c1a41975b30885537a47, type: 2}
+  m_Animations:
+  - {fileID: 7400000, guid: a2ff7923bbf1c1a41975b30885537a47, type: 2}
+  m_WrapMode: 0
+  m_PlayAutomatically: 0
+  m_AnimatePhysics: 0
+  m_CullingType: 0
+--- !u!114 &114000011299936470
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000010207501202}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a1b04f56ad1bfcf43ad356a7d124ade1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  SinkingAnimation: {fileID: 0}


### PR DESCRIPTION
## Issue
Upon health reaching zero player and pirate ships trigger the sinking animation, the GameObjects currently reset to the origin of 0,0,0.

## Fix
Move the Animation `SinkingAnimation` & `SinkingBehaviour.cs` into a child `GameObject` for both the `PirateShip` and `PlayerShip` prefabs.

## Test
Tested through tutorial to lesson 8 and noticed the issues as well as when spawning multiple clients in the tutorial for lesson 6 **Sink that ship**.